### PR TITLE
update pawnocchio config

### DIFF
--- a/Engines/Pawnocchio.json
+++ b/Engines/Pawnocchio.json
@@ -1,11 +1,11 @@
 {
     "private": false,
-    "nps": 1000000,
+    "nps": 2943546,
     "source": "https://github.com/JonathanHallstrom/pawnocchio",
 
     "build": {
         "path": "",
-        "compilers": ["zig=0.13.0"],
+        "compilers": ["zig"],
         "cpuflags": [],
         "systems": ["Linux", "Windows", "Darwin"]
     },


### PR DESCRIPTION
fixed the nps value, and changed the config to only require zig as i was getting `Missing zig=0.13.0` error