### PR TITLE
chore: update ByteKnight nps

### DIFF
--- a/Engines/ByteKnight.json
+++ b/Engines/ByteKnight.json
@@ -1,6 +1,6 @@
 {
     "private": false,
-    "nps": 975000,
+    "nps": 3695000,
     "source": "https://github.com/DeveloperPaul123/byte-knight",
     "build": {
         "path": "",


### PR DESCRIPTION
Current search-bench output on reference machine:

```bash
info depth 1 time 382 nodes 37 score cp 89 nps 96 pv g1f3
info depth 2 time 382 nodes 221 score cp 54 nps 577 pv g1f3
info depth 3 time 383 nodes 1405 score cp 89 nps 3668 pv g1f3
info depth 4 time 384 nodes 5673 score cp 55 nps 14744 pv g1f3
info depth 5 time 390 nodes 34888 score cp 88 nps 89351 pv g1f3
info depth 6 time 428 nodes 128990 score cp 55 nps 301090 pv g1f3
1583604 nodes 3695347 nps
```
