### PR TITLE
fix oopsie

### DIFF
--- a/Engines/Yukari.json
+++ b/Engines/Yukari.json
@@ -1,6 +1,6 @@
 {
     "private": false,
-    "nps": 13676181,
+    "nps": 1181694,
     "source": "https://github.com/yukarichess/yukari",
     "protocols": ["xboard"],
 


### PR DESCRIPTION
guess who accidentally pasted in their **bench number** instead of their NPS, and thus gave all nodes a x12 scaling offset >.>